### PR TITLE
Add question count, timer, and sequential answering

### DIFF
--- a/index.html
+++ b/index.html
@@ -188,6 +188,13 @@
             font-size: 1em;
         }
 
+        .timer {
+            text-align: right;
+            font-size: 1.1em;
+            color: #e74c3c;
+            margin-bottom: 15px;
+        }
+
         .score-display {
             background: linear-gradient(135deg, #f39c12 0%, #e67e22 100%);
             color: white;
@@ -281,6 +288,8 @@
                         <div id="score-progress" class="progress-fill"></div>
                     </div>
                 </div>
+
+                <div id="timer" class="timer"></div>
 
                 <div id="question-container" class="question-container">
                     <!-- 題目內容將由JavaScript動態生成 -->


### PR DESCRIPTION
## Summary
- allow selecting number of questions and time limit when a quiz begins
- display a countdown timer
- present one question at a time with automatic next-question flow
- show answer status and jump to a question

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886fc079ff48328a6a66bd3b98d765e