### PR TITLE
Enhance quiz with timer and question selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -216,6 +216,13 @@
             transition: width 0.3s ease;
         }
 
+        .timer {
+            text-align: right;
+            font-weight: bold;
+            margin-bottom: 10px;
+            color: #e74c3c;
+        }
+
         @media (max-width: 768px) {
             .container {
                 margin: 10px;
@@ -281,6 +288,8 @@
                         <div id="score-progress" class="progress-fill"></div>
                     </div>
                 </div>
+
+                <div id="timer" class="timer"></div>
 
                 <div id="question-container" class="question-container">
                     <!-- 題目內容將由JavaScript動態生成 -->


### PR DESCRIPTION
## Summary
- add timer display and style
- support choosing question count (5-50) and exam time when quiz starts
- show timer during quiz and auto submit when time ends
- show one question per page with auto-advance
- allow jumping to unanswered question numbers via status dialog

## Testing
- `node -c quiz-app.js`
- `node -c quiz-data.js`


------
https://chatgpt.com/codex/tasks/task_e_6886fc079ff48328a6a66bd3b98d765e