### PR TITLE
Implement visual status tracking with star marks

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,6 +101,13 @@
             margin-bottom: 10px;
         }
 
+        .question-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 10px;
+        }
+
         .question-text {
             font-size: 1.1em;
             line-height: 1.6;
@@ -140,6 +147,58 @@
 
         .option.incorrect {
             border-color: #e74c3c;
+            background: #fdeaea;
+        }
+
+        .star {
+            cursor: pointer;
+            margin-left: 5px;
+            color: #ccc;
+            font-size: 1.2em;
+        }
+
+        .star.active {
+            color: #f39c12;
+        }
+
+        .status-modal {
+            display: none;
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0, 0, 0, 0.5);
+            justify-content: center;
+            align-items: center;
+            z-index: 1000;
+        }
+
+        .status-content {
+            background: white;
+            padding: 20px;
+            border-radius: 10px;
+            max-height: 80vh;
+            overflow-y: auto;
+            width: 90%;
+            max-width: 400px;
+        }
+
+        .status-item {
+            padding: 8px 12px;
+            margin: 4px 0;
+            border-radius: 5px;
+            cursor: pointer;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .status-item.answered {
+            background: #d5f4e6;
+        }
+
+        .status-item.unanswered {
             background: #fdeaea;
         }
 
@@ -303,12 +362,19 @@
                     </div>
                     <button id="next-btn" class="btn">下一題</button>
                     <button id="submit-btn" class="btn btn-success" style="display: none;">提交答案</button>
-                    <button id="status-btn" class="btn btn-secondary">檢視答題狀態</button>
+                <button id="status-btn" class="btn btn-secondary">檢視答題狀態</button>
                 </div>
 
                 <div class="controls">
                     <button id="back-to-units" class="btn btn-secondary">返回單元選擇</button>
                     <button id="restart-quiz" class="btn">重新開始</button>
+                </div>
+            </div>
+            <div id="status-modal" class="status-modal">
+                <div class="status-content">
+                    <h3>答題狀態</h3>
+                    <div id="status-list"></div>
+                    <button id="close-status" class="btn btn-secondary" style="margin-top:10px;">關閉</button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- support marking questions with a star
- show star and answered state in a modal
- reset star data when restarting a quiz

## Testing
- `node -c quiz-app.js`

------
https://chatgpt.com/codex/tasks/task_e_68870ebfc150832882f8bd911fbd6114