### PR TITLE
Add responsive download sample format button

### DIFF
--- a/index.html
+++ b/index.html
@@ -431,7 +431,7 @@
                         <div class="col-md-4 d-grid gap-2">
                             <button id="import-btn" class="btn btn-primary">匯入單元題庫</button>
                             <button id="export-unit-btn" class="btn btn-outline-secondary">匯出單元題庫</button>
-                            <a href="import-format.json" download="" class="btn btn-outline-info">下載範例格式</a>
+                            <button id="download-format" class="btn btn-outline-secondary">下載範例格式</button>
                         </div>
                     </div>
 

--- a/quiz-app.js
+++ b/quiz-app.js
@@ -60,6 +60,7 @@ class QuizApp {
         this.importSubjectBtn = document.getElementById('import-subject-btn');
         this.exportSubjectBtn = document.getElementById('export-subject-btn');
         this.exportUnitBtn = document.getElementById('export-unit-btn');
+        this.downloadFormatBtn = document.getElementById('download-format');
         this.downloadPdfBtn = document.getElementById('download-pdf');
 
         this.addSubjectBtn = document.getElementById('add-subject');
@@ -106,6 +107,9 @@ class QuizApp {
         }
         if (this.exportUnitBtn) {
             this.exportUnitBtn.addEventListener('click', () => this.exportUnit());
+        }
+        if (this.downloadFormatBtn) {
+            this.downloadFormatBtn.addEventListener('click', () => this.downloadFormat());
         }
         if (this.selectConfirm) {
             this.selectConfirm.addEventListener('click', () => this.confirmSelection());
@@ -631,6 +635,13 @@ class QuizApp {
         a.download = `${unit.unit}.json`;
         a.click();
         URL.revokeObjectURL(url);
+    }
+
+    downloadFormat() {
+        const a = document.createElement('a');
+        a.href = 'import-format.json';
+        a.download = 'import-format.json';
+        a.click();
     }
 
     importSubject() {


### PR DESCRIPTION
## Summary
- add `下載範例格式` button styled like `匯出單元題庫`
- implement click handler to download `import-format.json`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6889cdaf9cfc83289ddebd489bbfca53