### PR TITLE
Fix button classes & add file status indicators

### DIFF
--- a/index.html
+++ b/index.html
@@ -424,36 +424,38 @@
                             </select>
                         </div>
 
-                        <div class="col-md-4">
+                        <div class="col-md-4 d-grid gap-2">
                             <input type="file" id="import-file" class="form-control" accept="application/json">
+                            <button id="file-status" class="btn btn-outline-dark disabled">未選擇檔案</button>
                         </div>
 
                         <div class="col-md-4 d-grid gap-2">
                             <button id="import-btn" class="btn btn-primary">匯入單元題庫</button>
                             <button id="export-unit-btn" class="btn btn-outline-secondary">匯出單元題庫</button>
-                            <button id="download-format-btn" class="btn btn-outline-secondary">下載範例格式</button>
+                            <button id="download-format-btn" class="btn btn-outline-info">下載範例格式</button>
                         </div>
                     </div>
                     <div class="row mb-4">
                         <div class="col-md-12 d-grid">
-                            <button id="edit-unit-btn" class="btn btn-outline-danger">編輯單元題庫（刪除題目）</button>
+                            <button id="edit-unit-btn" class="btn btn-primary">編輯單元題庫（刪除題目）</button>
                         </div>
                     </div>
 
                     <!-- 科目題庫操作 -->
                     <div class="row g-2 align-items-center">
-                        <div class="col-md-6">
+                        <div class="col-md-6 d-grid gap-2">
                             <input type="file" id="import-subject-file" class="form-control" accept="application/json">
+                            <button id="subject-file-status" class="btn btn-outline-dark disabled">未選擇檔案</button>
                         </div>
                         <div class="col-md-6 d-grid gap-2">
-                            <button id="import-subject-btn" class="btn btn-success">匯入科目題庫</button>
+                            <button id="import-subject-btn" class="btn btn-primary">匯入科目題庫</button>
                             <button id="export-subject-btn" class="btn btn-outline-secondary">匯出科目題庫</button>
                         </div>
                     </div>
                 </div>
                 <div class="controls">
-                    <button id="add-unit" class="btn">新增單元</button>
-                    <button id="remove-unit" class="btn btn-secondary">刪除單元</button>
+                    <button id="add-unit" class="btn btn-success">新增單元</button>
+                    <button id="remove-unit" class="btn btn-outline-danger">刪除單元</button>
                     <button id="back-to-subjects" class="btn btn-secondary">返回科目選擇</button>
                 </div>
             </div>

--- a/quiz-app.js
+++ b/quiz-app.js
@@ -68,6 +68,8 @@ class QuizApp {
         this.addUnitBtn = document.getElementById('add-unit');
         this.removeSubjectBtn = document.getElementById('remove-subject');
         this.removeUnitBtn = document.getElementById('remove-unit');
+        this.fileStatusBtn = document.getElementById('file-status');
+        this.subjectFileStatusBtn = document.getElementById('subject-file-status');
         
         this.currentPageSpan = document.getElementById('current-page');
         this.totalPagesSpan = document.getElementById('total-pages');
@@ -114,6 +116,18 @@ class QuizApp {
         }
         if (this.editUnitBtn) {
             this.editUnitBtn.addEventListener('click', () => this.editUnitQuestions());
+        }
+        if (this.importFile && this.fileStatusBtn) {
+            this.importFile.addEventListener('change', () => {
+                const file = this.importFile.files[0];
+                this.fileStatusBtn.textContent = file ? file.name : '未選擇檔案';
+            });
+        }
+        if (this.importSubjectFile && this.subjectFileStatusBtn) {
+            this.importSubjectFile.addEventListener('change', () => {
+                const file = this.importSubjectFile.files[0];
+                this.subjectFileStatusBtn.textContent = file ? file.name : '未選擇檔案';
+            });
         }
         if (this.selectConfirm) {
             this.selectConfirm.addEventListener('click', () => this.confirmSelection());


### PR DESCRIPTION
## Summary
- update classes for management buttons
- add disabled buttons to show file upload status
- display chosen file name for both subject and unit imports

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6889dc2eb9bc83289c36106e074f0f09