### PR TITLE
Support mixed question mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -482,14 +482,24 @@
             <div id="unit-selector" class="unit-selector" style="display:none;">
                 <div class="card file-ops p-4 shadow-sm rounded mb-4">
                     <h3 class="mb-3">請選擇要測驗的單元：</h3>
-                    <h4 class="section-title mb-2">單選題</h4>
-                    <div class="unit-buttons" id="single-unit-buttons">
-                        <!-- 單選單元按鈕將由JavaScript動態生成 -->
-                    </div>
-                    <h4 class="section-title mb-2" style="margin-top:20px;">多選題</h4>
-                    <div class="unit-buttons" id="multi-unit-buttons">
-                        <!-- 多選單元按鈕將由JavaScript動態生成 -->
-                    </div>
+                    <fieldset class="p-3 mb-4 shadow-sm rounded">
+                        <legend class="section-title">單選題</legend>
+                        <div class="unit-buttons" id="single-unit-buttons">
+                            <!-- 單選單元按鈕將由JavaScript動態生成 -->
+                        </div>
+                    </fieldset>
+                    <fieldset class="p-3 mb-4 shadow-sm rounded">
+                        <legend class="section-title">多選題</legend>
+                        <div class="unit-buttons" id="multi-unit-buttons">
+                            <!-- 多選單元按鈕將由JavaScript動態生成 -->
+                        </div>
+                    </fieldset>
+                    <fieldset class="p-3 shadow-sm rounded">
+                        <legend class="section-title">混合題</legend>
+                        <div class="unit-buttons" id="mixed-unit-buttons">
+                            <!-- 混合題按鈕將由JavaScript動態生成 -->
+                        </div>
+                    </fieldset>
                 </div>
                 <div class="card file-ops p-4 shadow-sm rounded">
                     <h4 class="section-title mb-3">📁 檔案管理操作</h4>


### PR DESCRIPTION
## Summary
- add fieldsets for mixed question units
- implement mixed question mode combining single and multiple questions
- allow per-question type handling when answering and grading

## Testing
- `node --check quiz-app.js`

------
https://chatgpt.com/codex/tasks/task_e_688ae1f863408328a6eed396be0c850c