### PR TITLE
Fix question progress bar visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -340,7 +340,7 @@
             margin-bottom: 10px;
         }
 
-        .progress-bar {
+        .score-bar {
             background: #e9ecef;
             border-radius: 10px;
             height: 8px;
@@ -619,7 +619,7 @@
                 <div id="score-display" class="score-display" style="display: none;">
                     <h3>測驗結果</h3>
                     <p id="score-text"></p>
-                    <div class="progress-bar">
+                    <div class="score-bar">
                         <div id="score-progress" class="progress-fill"></div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- rename custom `.progress-bar` style to `.score-bar`
- update result section markup accordingly

This prevents our custom styles from overriding the Bootstrap progress bar used for question progress.

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688b80862fd48328a54d9a65df96c788