### PR TITLE
Fix quiz buttons layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -631,25 +631,13 @@
                 </div>
 
                 <div id="quiz-controls" class="container mt-4">
-                    <div class="row row-cols-2 row-cols-sm-3 row-cols-lg-6 g-2">
-                        <div class="col">
-                            <button id="prev-btn" class="btn btn-outline-secondary btn-sm w-100">上一題</button>
-                        </div>
-                        <div class="col">
-                            <button id="next-btn" class="btn btn-primary btn-sm w-100">下一題</button>
-                        </div>
-                        <div class="col">
-                            <button id="submit-btn" class="btn btn-success btn-sm w-100" style="display:none;">✅ 結束作答</button>
-                        </div>
-                        <div class="col">
-                            <button id="status-btn" class="btn btn-outline-dark btn-sm w-100">👁 檢視答題狀態</button>
-                        </div>
-                        <div class="col">
-                            <button id="back-to-units" class="btn btn-outline-secondary btn-sm w-100">🔙 返回單元選擇</button>
-                        </div>
-                        <div class="col">
-                            <button id="restart-quiz" class="btn btn-outline-primary btn-sm w-100">🔁 重新開始</button>
-                        </div>
+                    <div class="file-ops-buttons">
+                        <button id="prev-btn" class="btn btn-outline-secondary btn-sm">上一題</button>
+                        <button id="next-btn" class="btn btn-primary btn-sm">下一題</button>
+                        <button id="submit-btn" class="btn btn-success btn-sm" style="display:none;">✅ 結束作答</button>
+                        <button id="status-btn" class="btn btn-outline-dark btn-sm">👁 檢視答題狀態</button>
+                        <button id="back-to-units" class="btn btn-outline-secondary btn-sm">🔙 返回單元選擇</button>
+                        <button id="restart-quiz" class="btn btn-outline-primary btn-sm">🔁 重新開始</button>
                     </div>
                     <div class="progress mt-3" style="height: 6px;">
                         <div id="question-progress" class="progress-bar" role="progressbar" style="width: 0%;"></div>


### PR DESCRIPTION
## Summary
- mimic file management button layout in quiz area

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688b88c834c083288a48c09e0ce77ae6