### PR TITLE
fix: remove header side padding

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
             border-radius: 15px;
             box-shadow: 0 20px 40px rgba(0,0,0,0.1);
             overflow: hidden;
+            padding: 0;
         }
 
         .header {
@@ -630,7 +631,7 @@
                     <!-- 題目內容將由JavaScript動態生成 -->
                 </div>
 
-                <div id="quiz-controls" class="container mt-4">
+                <div id="quiz-controls" class="container mt-4 px-3">
                     <div class="file-ops-buttons">
                         <button id="prev-btn" class="btn btn-outline-secondary btn-sm">上一題</button>
                         <button id="next-btn" class="btn btn-primary btn-sm">下一題</button>


### PR DESCRIPTION
## Summary
- remove container padding to eliminate header side whitespace
- restore padding for quiz control section

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688c09739bfc8328bc44f207fe24ba5e