### PR TITLE
fix: align file management buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -209,8 +209,8 @@
         }
 
         .file-ops-buttons {
-            display: flex;
-            flex-wrap: wrap;
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
             gap: 8px;
         }
 
@@ -227,11 +227,7 @@
 
         @media (max-width: 576px) {
             .file-ops-buttons {
-                flex-direction: column;
-                align-items: stretch;
-            }
-            .file-ops-buttons .btn {
-                width: 100%;
+                grid-template-columns: 1fr;
             }
         }
 


### PR DESCRIPTION
## Summary
- switch file operation button groups to CSS grid for consistent ordering
- simplify media query to stack buttons on narrow screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688c0bb747848328bfa892713a2e3371