### PR TITLE
Adjust quiz controls layout and PDF export

### DIFF
--- a/index.html
+++ b/index.html
@@ -642,7 +642,7 @@
                     <!-- 題目內容將由JavaScript動態生成 -->
                 </div>
 
-                <div id="quiz-controls" class="container mt-4 px-3">
+                <div id="quiz-controls" class="mt-4 px-3">
                     <div class="file-ops-buttons mb-3">
                         <button id="prev-btn" class="btn btn-outline-secondary btn-sm">上一題</button>
                         <button id="next-btn" class="btn btn-primary btn-sm">下一題</button>
@@ -652,11 +652,11 @@
                         <button id="restart-quiz" class="btn btn-outline-primary btn-sm">🔁 重新開始</button>
                         <button id="download-pdf" class="btn btn-success btn-sm" style="display:none;">下載結果PDF</button>
                     </div>
-                    <div class="position-relative mt-4 mb-2">
+                    <div class="mt-4 mb-2">
                         <div class="progress" style="height: 8px;">
                             <div id="question-progress" class="progress-bar" role="progressbar" style="width: 0%;"></div>
                         </div>
-                        <small id="progress-text" class="position-absolute top-50 start-50 translate-middle fw-bold text-dark">1 / 1</small>
+                        <small id="progress-text" class="d-block text-center fw-bold text-dark mt-2">1 / 1</small>
                     </div>
                 </div>
             </div>

--- a/quiz-app.js
+++ b/quiz-app.js
@@ -1162,10 +1162,26 @@ class QuizApp {
         });
 
         document.body.appendChild(container);
-        html2canvas(container).then(canvas => {
-            const pdf = new jsPDF({orientation: 'p', unit: 'px', format: [canvas.width, canvas.height]});
+        html2canvas(container, { scale: 2 }).then(canvas => {
+            const pdf = new jsPDF({ orientation: 'p', unit: 'mm', format: 'a4' });
             const imgData = canvas.toDataURL('image/png');
-            pdf.addImage(imgData, 'PNG', 0, 0, canvas.width, canvas.height);
+            const pageWidth = pdf.internal.pageSize.getWidth();
+            const pageHeight = pdf.internal.pageSize.getHeight();
+            const imgWidth = pageWidth;
+            const imgHeight = canvas.height * imgWidth / canvas.width;
+            let heightLeft = imgHeight;
+            let position = 0;
+
+            pdf.addImage(imgData, 'PNG', 0, position, imgWidth, imgHeight);
+            heightLeft -= pageHeight;
+
+            while (heightLeft > 0) {
+                position = heightLeft - imgHeight;
+                pdf.addPage();
+                pdf.addImage(imgData, 'PNG', 0, position, imgWidth, imgHeight);
+                heightLeft -= pageHeight;
+            }
+
             pdf.save('quiz-result.pdf');
             document.body.removeChild(container);
         });


### PR DESCRIPTION
## Summary
- remove container styling from quiz controls and center progress text
- add spacing around progress bar for stacked layouts
- export quiz results PDF using A4 pages with multi-page support

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c286d33088328aae4fc1f27024817