### PR TITLE
Fix PDF export and restart handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -375,16 +375,14 @@
         }
 
         .progress-container {
-            position: relative;
             margin-top: 20px;
             margin-bottom: 10px;
+            text-align: center;
         }
 
         #progress-text {
-            position: absolute;
-            top: 50%;
-            left: 50%;
-            transform: translate(-50%, -50%);
+            display: block;
+            margin-top: 5px;
             font-weight: bold;
             color: #2c3e50;
         }
@@ -708,6 +706,7 @@
     </footer>
     <div id="toast" class="toast"></div>
     <script src="quiz-data.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
     <script src="quiz-app.js"></script>
 </body>

--- a/quiz-app.js
+++ b/quiz-app.js
@@ -798,8 +798,44 @@ class QuizApp {
     }
 
     restartQuiz() {
+        const allQuestions = this.getAllQuestions();
+        let newQuestions = [];
+
+        if (this.currentUnitType === 'mixed') {
+            const singleQ = allQuestions
+                .filter(q => !Array.isArray(q.answers))
+                .sort(() => Math.random() - 0.5)
+                .slice(0, 40);
+            const multiQ = allQuestions
+                .filter(q => Array.isArray(q.answers))
+                .sort(() => Math.random() - 0.5)
+                .slice(0, 10);
+            newQuestions = singleQ.concat(multiQ).sort(() => Math.random() - 0.5);
+        } else {
+            const maxQuestions = Math.min(50, allQuestions.length);
+            const countInput = prompt(`請輸入測驗題數 (5-${maxQuestions})`, Math.min(10, maxQuestions));
+            if (countInput === null) {
+                return;
+            }
+            let count = parseInt(countInput);
+            if (isNaN(count)) count = Math.min(10, maxQuestions);
+            count = Math.min(Math.max(count, 5), maxQuestions);
+            const shuffled = allQuestions.sort(() => Math.random() - 0.5);
+            newQuestions = shuffled.slice(0, count);
+        }
+
+        const timeInput = prompt('請輸入測驗時間(分鐘)', this.timeLimit / 60);
+        if (timeInput === null) {
+            return;
+        }
+        let timeMin = parseInt(timeInput);
+        if (isNaN(timeMin) || timeMin <= 0) timeMin = this.timeLimit / 60;
+        this.timeLimit = timeMin * 60;
+
         this.resetQuiz();
-        this.startQuiz(this.currentUnit, this.currentUnitType);
+        this.selectedQuestions = newQuestions;
+        this.startTimer();
+        this.renderQuiz();
     }
 
     resetQuiz() {


### PR DESCRIPTION
## Summary
- load `html2canvas` to enable result PDF download
- reposition quiz progress text below bar to avoid overlap
- add restart flow that prompts for question count/time and cancels cleanly

## Testing
- `node --check quiz-app.js`
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688c2dbbbacc832882a30ec8255173c5