### PR TITLE
feat: sync question bank dropdowns

### DIFF
--- a/index.html
+++ b/index.html
@@ -623,6 +623,7 @@
                             <div class="col file-ops-buttons">
                                 <button id="add-unit" class="btn btn-sm">新增單元</button>
                                 <button id="remove-unit" class="btn btn-secondary btn-sm">刪除單元</button>
+                                <button id="sync-to-multi" class="btn btn-warning btn-sm">同步到多選</button>
                             </div>
                         </div>
                     </fieldset>
@@ -657,6 +658,7 @@
                             <div class="col file-ops-buttons">
                                 <button id="add-unit-multi" class="btn btn-sm">新增單元</button>
                                 <button id="remove-unit-multi" class="btn btn-secondary btn-sm">刪除單元</button>
+                                <button id="sync-to-single" class="btn btn-warning btn-sm">同步到單選</button>
                             </div>
                         </div>
                     </fieldset>

--- a/quiz-app.js
+++ b/quiz-app.js
@@ -89,6 +89,8 @@ class QuizApp {
         this.removeSubjectBtn = document.getElementById('remove-subject');
         this.removeUnitBtn = document.getElementById('remove-unit');
         this.removeUnitMultiBtn = document.getElementById('remove-unit-multi');
+        this.syncToMultiBtn = document.getElementById('sync-to-multi');
+        this.syncToSingleBtn = document.getElementById('sync-to-single');
         
         this.currentPageSpan = document.getElementById('current-page');
         this.totalPagesSpan = document.getElementById('total-pages');
@@ -157,6 +159,12 @@ class QuizApp {
         }
         if (this.removeUnitMultiBtn) {
             this.removeUnitMultiBtn.addEventListener('click', () => this.removeUnitMulti());
+        }
+        if (this.syncToMultiBtn) {
+            this.syncToMultiBtn.addEventListener('click', () => this.syncToMulti());
+        }
+        if (this.syncToSingleBtn) {
+            this.syncToSingleBtn.addEventListener('click', () => this.syncToSingle());
         }
         if (this.importAllBtn) {
             this.importAllBtn.addEventListener('click', () => this.importAllQuestions());
@@ -1105,6 +1113,29 @@ class QuizApp {
             this.saveToStorage();
             this.renderUnitSelector();
         });
+    }
+
+    syncToMulti() {
+        if (this.currentSubject == null) return;
+        if (!confirm('確定將單選題庫下拉選單同步至多選題庫？\n此操作僅同步單元名稱，不會同步題目。')) return;
+        const source = subjects[this.currentSubject].units || [];
+        subjects[this.currentSubject].multiUnits = source.map(u => ({ unit: u.unit, questions: [] }));
+        this.currentMultiUnits = subjects[this.currentSubject].multiUnits;
+        this.saveToStorage();
+        this.renderUnitSelector();
+        this.showToast('已同步到多選題庫');
+    }
+
+    syncToSingle() {
+        if (this.currentSubject == null) return;
+        if (!confirm('確定將多選題庫下拉選單同步至單選題庫？\n此操作僅同步單元名稱，不會同步題目。')) return;
+        const source = subjects[this.currentSubject].multiUnits || [];
+        subjects[this.currentSubject].units = source.map(u => ({ unit: u.unit, questions: [] }));
+        this.currentSingleUnits = subjects[this.currentSubject].units;
+        this.currentSubjectData = this.currentSingleUnits;
+        this.saveToStorage();
+        this.renderUnitSelector();
+        this.showToast('已同步到單選題庫');
     }
 
     editUnitQuestions() {


### PR DESCRIPTION
## Summary
- add buttons to sync unit dropdowns between single and multi question banks
- handle syncing logic with confirmation prompts and storage updates

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688c7bb84060832885a0a10289ff00bc