### PR TITLE
feat: sync unit dropdowns across question banks

### DIFF
--- a/index.html
+++ b/index.html
@@ -621,6 +621,7 @@
                         </div>
                         <div class="row g-2 align-items-center mt-2">
                             <div class="col file-ops-buttons">
+                                <button id="sync-unit-to-multi" class="btn btn-outline-info btn-sm">同步到多選題庫</button>
                                 <button id="add-unit" class="btn btn-sm">新增單元</button>
                                 <button id="remove-unit" class="btn btn-secondary btn-sm">刪除單元</button>
                             </div>
@@ -655,6 +656,7 @@
                         </div>
                         <div class="row g-2 align-items-center mt-2">
                             <div class="col file-ops-buttons">
+                                <button id="sync-unit-multi-to-single" class="btn btn-outline-info btn-sm">同步到單選題庫</button>
                                 <button id="add-unit-multi" class="btn btn-sm">新增單元</button>
                                 <button id="remove-unit-multi" class="btn btn-secondary btn-sm">刪除單元</button>
                             </div>

--- a/quiz-app.js
+++ b/quiz-app.js
@@ -89,6 +89,8 @@ class QuizApp {
         this.removeSubjectBtn = document.getElementById('remove-subject');
         this.removeUnitBtn = document.getElementById('remove-unit');
         this.removeUnitMultiBtn = document.getElementById('remove-unit-multi');
+        this.syncUnitToMultiBtn = document.getElementById('sync-unit-to-multi');
+        this.syncUnitMultiToSingleBtn = document.getElementById('sync-unit-multi-to-single');
         
         this.currentPageSpan = document.getElementById('current-page');
         this.totalPagesSpan = document.getElementById('total-pages');
@@ -157,6 +159,12 @@ class QuizApp {
         }
         if (this.removeUnitMultiBtn) {
             this.removeUnitMultiBtn.addEventListener('click', () => this.removeUnitMulti());
+        }
+        if (this.syncUnitToMultiBtn) {
+            this.syncUnitToMultiBtn.addEventListener('click', () => this.syncSingleToMulti());
+        }
+        if (this.syncUnitMultiToSingleBtn) {
+            this.syncUnitMultiToSingleBtn.addEventListener('click', () => this.syncMultiToSingle());
         }
         if (this.importAllBtn) {
             this.importAllBtn.addEventListener('click', () => this.importAllQuestions());
@@ -1105,6 +1113,29 @@ class QuizApp {
             this.saveToStorage();
             this.renderUnitSelector();
         });
+    }
+
+    syncSingleToMulti() {
+        if (this.currentSubject == null) return;
+        if (!confirm('確定要同步單選題庫單元至多選題庫？(僅同步下拉選單，不會同步題目)')) return;
+        const units = this.currentSingleUnits.map(u => ({ unit: u.unit, questions: [] }));
+        this.currentMultiUnits = units;
+        subjects[this.currentSubject].multiUnits = units;
+        this.saveToStorage();
+        this.renderUnitSelector();
+        this.showToast('多選題庫下拉選單已同步');
+    }
+
+    syncMultiToSingle() {
+        if (this.currentSubject == null) return;
+        if (!confirm('確定要同步多選題庫單元至單選題庫？(僅同步下拉選單，不會同步題目)')) return;
+        const units = this.currentMultiUnits.map(u => ({ unit: u.unit, questions: [] }));
+        this.currentSingleUnits = units;
+        this.currentSubjectData = units;
+        subjects[this.currentSubject].units = units;
+        this.saveToStorage();
+        this.renderUnitSelector();
+        this.showToast('單選題庫下拉選單已同步');
     }
 
     editUnitQuestions() {


### PR DESCRIPTION
## Summary
- allow single-question bank units to sync into multi-question bank dropdown
- allow multi-question bank units to sync back into single-question bank dropdown

## Testing
- `node --check quiz-app.js`
- `node --check quiz-data.js`
- `node --check index.html` *(fails: Unknown file extension ".html" for index.html)*

------
https://chatgpt.com/codex/tasks/task_e_688c7bb84060832885a0a10289ff00bc