### PR TITLE
feat: disable sync when no units

### DIFF
--- a/quiz-app.js
+++ b/quiz-app.js
@@ -319,6 +319,17 @@ class QuizApp {
             mixBtn.addEventListener('click', () => this.startQuiz(-1, 'mixed'));
             this.mixedUnitButtons.appendChild(mixBtn);
         }
+
+        this.updateSyncButtons();
+    }
+
+    updateSyncButtons() {
+        if (this.syncUnitToMultiBtn) {
+            this.syncUnitToMultiBtn.disabled = this.currentSingleUnits.length === 0;
+        }
+        if (this.syncUnitMultiToSingleBtn) {
+            this.syncUnitMultiToSingleBtn.disabled = this.currentMultiUnits.length === 0;
+        }
     }
 
     startQuiz(unitIndex, type = 'single', predefinedCount = null, predefinedTime = null) {
@@ -1117,6 +1128,7 @@ class QuizApp {
 
     syncSingleToMulti() {
         if (this.currentSubject == null) return;
+        if (!this.currentSingleUnits.length) return;
         if (!confirm('確定要同步單選題庫單元至多選題庫？(僅同步下拉選單，不會同步題目)')) return;
         const units = this.currentSingleUnits.map(u => ({ unit: u.unit, questions: [] }));
         this.currentMultiUnits = units;
@@ -1128,6 +1140,7 @@ class QuizApp {
 
     syncMultiToSingle() {
         if (this.currentSubject == null) return;
+        if (!this.currentMultiUnits.length) return;
         if (!confirm('確定要同步多選題庫單元至單選題庫？(僅同步下拉選單，不會同步題目)')) return;
         const units = this.currentMultiUnits.map(u => ({ unit: u.unit, questions: [] }));
         this.currentSingleUnits = units;


### PR DESCRIPTION
## Summary
- avoid syncing empty question banks by disabling sync buttons when dropdowns have no units
- block sync functions if no units are present

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688c7f8d7a2c8328a00792a26f94b68e